### PR TITLE
Update ca-certifactes, curl and gnupg2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV CURL_VERSION=7.88.1-10+deb12u14
 # renovate: datasource=repology depName=debian_12/lsb-release versioning=deb
 ENV LSBRELEASE_VERSION=12.0-1
 # renovate: datasource=repology depName=debian_12/gnupg2 versioning=deb
-ENV GNUPG_VERSION=2.2.40-1.1
+ENV GNUPG_VERSION=2.2.40-1.1+deb12u1
 
 RUN apt-get update -y && \
   # Install necessary dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:12.11-slim AS base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
-ENV CACERTIFICATES_VERSION=20230311
+ENV CACERTIFICATES_VERSION=20230311+deb12u1
 
 RUN apt-get update -y && \
   # Install necessary dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM base AS build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # renovate: datasource=repology depName=debian_12/curl versioning=deb
-ENV CURL_VERSION=7.88.1-10+deb12u12
+ENV CURL_VERSION=7.88.1-10+deb12u14
 # renovate: datasource=repology depName=debian_12/lsb-release versioning=deb
 ENV LSBRELEASE_VERSION=12.0-1
 # renovate: datasource=repology depName=debian_12/gnupg2 versioning=deb


### PR DESCRIPTION
Updates various packages to newer versions
- `ca-certificates` to `20230311+deb12u1`
- `curl` to `7.88.1-10+deb12u14` (changes from https://github.com/swissgrc/docker-azure-pipelines-dockercli/pull/128)
- `gnupg2` to `2.2.40-1.1+deb12u1` (changes from https://github.com/swissgrc/docker-azure-pipelines-dockercli/pull/129)

Due to removal of old versions, we can not individually update them.